### PR TITLE
WIP Fix update password not required in update, symbols not req in signup, username prefilled in login after signup -  lost during last merge 

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -7,7 +7,7 @@ from app.models import Account
 class SignUpForm(FlaskForm):
     username = StringField('Username', validators=[InputRequired(), Length(min=2, max=15)])
     email = StringField('Email', validators=[InputRequired(), Email(message='Invalid Email'), Length(max=30)])
-    password = PasswordField('Password', validators=[InputRequired(), Length(min=2, max=15)])
+    password = PasswordField('Password')
     stocks = StringField('stocks', validators=[ Length(min=2, max=50)])
     submit = SubmitField('Submit')
 

--- a/app/templates/update.html
+++ b/app/templates/update.html
@@ -9,7 +9,7 @@
             {{ form.csrf_token }}
             <div class="form-group">
                 <label class="text-light">Username</label>
-                {{ form.username(class="form-control bg-dark text-light border-0", placeholder="Enter Username",) }}
+                {{ form.username(class="form-control bg-dark text-light border-0", placeholder="Enter Username") }}
             </div>
             <div class="form-group">
                 <label for="email-input">Email</label>
@@ -17,7 +17,7 @@
             </div>
             <div class="form-group">
                 <label for="password-input">Password</label>
-                <input name="password" type="password" class="form-control bg-dark text-light border-0" id="password-input" placeholder="Enter Password (Not Required)" required>
+                <input name="password" type="password" class="form-control bg-dark text-light border-0" id="password-input" placeholder="Enter Password (Not Required)">
             </div>
             <div class="form-group">
                 <label for="stock-input">Symbols</label>


### PR DESCRIPTION
Find and place code back in lost from prior merge.

**Complete:**
~- User should not have to enter a password when updating account information.~ [Included this when I reverted changes to main and re-merged feat/#60-responsive-styles]

**Remaining:** 
- Fix Signup, user should not be required to enter symbols at signup.
- When user signs up and is redirected to login, the username should be prefilled.